### PR TITLE
fix for missing attitude file

### DIFF
--- a/uvot-mosaic/uvot_deep.py
+++ b/uvot-mosaic/uvot_deep.py
@@ -147,7 +147,6 @@ def uvot_deep(input_folders,
             if not os.path.isfile(att_uat):
                 print('Could not create ', att_uat)
                 print('Skipping segment')
-                pdb.set_trace()
                 continue
 
             # scattered light images

--- a/uvot-mosaic/uvot_deep.py
+++ b/uvot-mosaic/uvot_deep.py
@@ -142,6 +142,13 @@ def uvot_deep(input_folders,
                 cmd = 'uvotattcorr attfile=' + att_sat + ' corrfile=' + corr_file + ' outfile=' + att_uat
                 subprocess.run(cmd, shell=True)
 
+            # if the file wasn't created (likely because of no aspect
+            # corrections for anything), this segment can't be processed
+            if not os.path.isfile(att_uat):
+                print('Could not create ', att_uat)
+                print('Skipping segment')
+                pdb.set_trace()
+                continue
 
             # scattered light images
             if scattered_light:


### PR DESCRIPTION
Works around the problem in #11.  If `uvot_deep.py` attempts to make the more accurate attitude file and fails, it prints out a warning and skips the segment.
